### PR TITLE
Fixing a typescript compilation issue related to 'createTextRange' not existing on type 'HTMLInputElement' 

### DIFF
--- a/src/masked-input.ts
+++ b/src/masked-input.ts
@@ -560,9 +560,9 @@ export class MaskedInput {
                 this.inputElement.setSelectionRange(pos, pos);
             }
         }
-        else if (this.inputElement.createTextRange) {
+        else if ((<any>this.inputElement).createTextRange) {
             // Curse you IE
-            var range = this.inputElement.createTextRange();
+            var range = (<any>this.inputElement).createTextRange();
             range.collapse(true);
             range.moveEnd('character', pos);
             range.moveStart('character', pos);


### PR DESCRIPTION
Including the "aurelia-mask" package in our (webpack 2-based) project resulted in packing problems due to the inclusion of typescript files in the "dist" folder.  We decided to no longer exclude "node_modules" for the ts-loader, but we then ran into the following compilation errors:

```
ERROR in ./node_modules/aurelia-mask/dist/masked-input.ts
(563,36): error TS2339: Property 'createTextRange' does not exist on type 'HTMLInputElement'.

ERROR in ./node_modules/aurelia-mask/dist/masked-input.ts
(565,42): error TS2339: Property 'createTextRange' does not exist on type 'HTMLInputElement'.
```


The goal of this pull request is to resolve these compilation errors. I've mimicked the approach used to access ".selection" elsewhere in the file.  

Our project uses typescript version 2.4.2, targetting "es5" with module code generation "es2015".

